### PR TITLE
Added prefetch config option

### DIFF
--- a/src/lib/index/subscribe.js
+++ b/src/lib/index/subscribe.js
@@ -27,6 +27,7 @@
 'use strict';
 
 const
+	_ = require('lodash'),
 	Amqp = require('./shared/amqp'),
 
 	EventEmitter = require('events'),
@@ -35,23 +36,27 @@ const
 
 	emitter = new EventEmitter(),
 
-	subscribeAction = ({ topic, handler, channel }) => {
+	subscribeAction = ({ topic, handler, channel, config }) => {
 		// Ensure the topic exists
 		channel.assertQueue(topic);
-
+		// Set prefetch
+		if (config.prefetch && _.isInteger(config.prefetch)) {
+			channel.prefetch(config.prefetch);
+		}
 		// Subscribe to the topic
 		return channel.consume(topic, message => {
 			return Promise.resolve()
 				.then(() => {
-					// Invoke the handler with the message
+					// Invoke the handler with the message, and return the result promise or a resolution
 					try {
 						const handlerResult = handler(message.content);
-						Promise.resolve(handlerResult).catch(err => {
+						return Promise.resolve(handlerResult).catch(err => {
 							emitter.emit(ERROR_EVENT, err.message);
 						});
 					} catch (err) {
 						emitter.emit(ERROR_EVENT, err.message);
 					}
+					return Promise.resolve();
 				})
 				.then(result => channel.ack(message));
 		});
@@ -59,7 +64,7 @@ const
 
 	handle = ({ eventName, handler, config }) => {
 		// Opens a connection to the RabbitMQ server, and subscribes to the topic
-		return Amqp.apply(channel => subscribeAction({ topic: eventName, handler, channel }), config)
+		return Amqp.apply(channel => subscribeAction({ topic: eventName, handler, channel, config }), config)
 			.catch(err => {
 				emitter.emit(ERROR_EVENT, err.message);
 				throw err;

--- a/src/lib/index/subscribe.js
+++ b/src/lib/index/subscribe.js
@@ -45,20 +45,10 @@ const
 		}
 		// Subscribe to the topic
 		return channel.consume(topic, message => {
-			return Promise.resolve()
-				.then(() => {
-					// Invoke the handler with the message, and return the result promise or a resolution
-					try {
-						const handlerResult = handler(message.content);
-						return Promise.resolve(handlerResult).catch(err => {
-							emitter.emit(ERROR_EVENT, err.message);
-						});
-					} catch (err) {
-						emitter.emit(ERROR_EVENT, err.message);
-					}
-					return Promise.resolve();
-				})
-				.then(result => channel.ack(message));
+			return Promise.resolve(message.content)
+				.then(handler)
+				.catch(err => emitter.emit(ERROR_EVENT, err.message))
+				.then(result => channel.ack(message)); // finally
 		});
 	},
 


### PR DESCRIPTION
So we can limit the number of messages we receive before we acknowledge them as complete.
Also fixed a bug where we weren't returning the callback promise so the ack was immediate.