### PR TITLE
Feature/add transport class

### DIFF
--- a/CHANGELOG-3.md
+++ b/CHANGELOG-3.md
@@ -2,11 +2,11 @@
 
 ## v3.2.2
 
-Dependency update for security advisories.
+- Dependency update for security advisories.
 
 ## v3.2.1
 
-Bug fix release.
+- Bug fix release.
 
 ### BUGS FIXED
 

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -4,7 +4,7 @@
 
 - Update Orizuru to use a class for the transport layer.
 	- Each server, publisher and handler should have a different transport instance.
-	- The configuration for the transport can be provided in the constructor therrby removing the requirement of transportConfig from Orizuru.
+	- The configuration for the transport can be provided in the constructor thereby removing the requirement of transportConfig from Orizuru.
 - Update all references to the Orizuru.Options; use Orizuru.Transport... instead.
 - Remove the use of Orizuru.Transport.IConnect.
 - Remove the Orizuru dev dependency.

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,3 +1,5 @@
 ## Latest
 
-- Conversion to Typescript.
+### FIXES
+
+- Make sure that the `connection` is reset to undefined after it has been closed.

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,5 +1,12 @@
 ## Latest
 
-### FIXES
+## 5.0.0-0 PREMAJOR
 
-- Make sure that the `connection` is reset to undefined after it has been closed.
+- Update Orizuru to use a class for the transport layer.
+	- Each server, publisher and handler should have a different transport instance.
+	- The configuration for the transport can be provided in the constructor therrby removing the requirement of transportConfig from Orizuru.
+- Update all references to the Orizuru.Options; use Orizuru.Transport... instead.
+- Remove the use of Orizuru.Transport.IConnect.
+- Remove the Orizuru dev dependency.
+
+- Add nyc.opts file to clean up the package.json.

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,17 +100,6 @@
 				"globals": "^11.1.0",
 				"invariant": "^2.2.0",
 				"lodash": "^4.17.5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/types": {
@@ -134,19 +123,33 @@
 			}
 		},
 		"@sinonjs/formatio": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+			"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
 			"dev": true,
 			"requires": {
-				"samsam": "1.3.0"
+				"@sinonjs/samsam": "2.1.0"
+			},
+			"dependencies": {
+				"@sinonjs/samsam": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+					"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+					"dev": true,
+					"requires": {
+						"array-from": "^2.1.1"
+					}
+				}
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-			"integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
-			"dev": true
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
+			"integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
+			"dev": true,
+			"requires": {
+				"array-from": "^2.1.1"
+			}
 		},
 		"@types/amqplib": {
 			"version": "0.5.8",
@@ -164,9 +167,9 @@
 			"integrity": "sha512-xlehmc6RT+wMEhy9ZqeqmozVmuFzTfsaV2NlfFFWhigy7n6sjMbUUB+SZBWK78lZgWHA4DBAdQvQxUvcB8N1tw=="
 		},
 		"@types/chai": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
-			"integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
+			"integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
 			"dev": true
 		},
 		"@types/chai-as-promised": {
@@ -239,9 +242,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.7.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-			"integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+			"version": "10.11.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
+			"integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ=="
 		},
 		"@types/shelljs": {
 			"version": "0.8.0",
@@ -254,9 +257,9 @@
 			}
 		},
 		"@types/sinon": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.1.tgz",
-			"integrity": "sha512-yxzBCIjE3lp9lYjfBbIK/LRCoXgCLLbIIBIje7eNCcUIIR2CZZtyX5uto2hVoMSMqLrsRrT6mwwUEd0yFgOwpA==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.2.tgz",
+			"integrity": "sha512-ifYuFq3GWyvRbqebGB4ZKLqezMGLXzhHv1Uefhg+uARYs/iO+v6Gu/BkpxTxsyM9NI++N/RCf5sWl3X9wBVLaw==",
 			"dev": true
 		},
 		"@types/sinon-chai": {
@@ -321,6 +324,12 @@
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -449,17 +458,17 @@
 			}
 		},
 		"chai": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
 			"dev": true,
 			"requires": {
-				"assertion-error": "^1.0.1",
-				"check-error": "^1.0.1",
-				"deep-eql": "^3.0.0",
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
-				"pathval": "^1.0.0",
-				"type-detect": "^4.0.0"
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
 			}
 		},
 		"chai-as-promised": {
@@ -541,6 +550,23 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
+		"debug": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+			"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -619,9 +645,9 @@
 			}
 		},
 		"globals": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+			"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -780,9 +806,9 @@
 			}
 		},
 		"just-extend": {
-			"version": "1.1.27",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
 			"dev": true
 		},
 		"kind-of": {
@@ -802,9 +828,9 @@
 			"optional": true
 		},
 		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -813,9 +839,9 @@
 			"dev": true
 		},
 		"lolex": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-			"integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+			"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
 			"dev": true
 		},
 		"longest": {
@@ -906,62 +932,49 @@
 			"dev": true
 		},
 		"nise": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.3.tgz",
-			"integrity": "sha512-cg44dkGHutAY+VmftgB1gHvLWxFl2vwYdF8WpbceYicQwylESRJiAAKgCRJntdoEbMiUzywkZEUzjoDWH0JwKA==",
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
+			"integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"just-extend": "^1.1.27",
+				"@sinonjs/formatio": "3.0.0",
+				"just-extend": "^3.0.0",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
-			},
-			"dependencies": {
-				"path-to-regexp": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-					"dev": true,
-					"requires": {
-						"isarray": "0.0.1"
-					}
-				}
 			}
 		},
 		"nyc": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
-			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.0.1.tgz",
+			"integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
 			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
-				"caching-transform": "^1.0.0",
+				"caching-transform": "^2.0.0",
 				"convert-source-map": "^1.5.1",
 				"debug-log": "^1.0.1",
-				"default-require-extensions": "^1.0.0",
-				"find-cache-dir": "^0.1.1",
-				"find-up": "^2.1.0",
-				"foreground-child": "^1.5.3",
-				"glob": "^7.0.6",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.1.0",
-				"istanbul-lib-instrument": "^2.1.0",
-				"istanbul-lib-report": "^1.1.3",
-				"istanbul-lib-source-maps": "^1.2.5",
-				"istanbul-reports": "^1.4.1",
-				"md5-hex": "^1.2.0",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.2",
+				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-hook": "^2.0.1",
+				"istanbul-lib-instrument": "^2.3.2",
+				"istanbul-lib-report": "^2.0.1",
+				"istanbul-lib-source-maps": "^2.0.1",
+				"istanbul-reports": "^2.0.0",
+				"make-dir": "^1.3.0",
 				"merge-source-map": "^1.1.0",
-				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.0",
-				"resolve-from": "^2.0.0",
+				"resolve-from": "^4.0.0",
 				"rimraf": "^2.6.2",
-				"signal-exit": "^3.0.1",
+				"signal-exit": "^3.0.2",
 				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^4.2.0",
+				"test-exclude": "^5.0.0",
+				"uuid": "^3.3.2",
 				"yargs": "11.1.0",
-				"yargs-parser": "^8.0.0"
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"align-text": {
@@ -985,35 +998,15 @@
 					"dev": true
 				},
 				"append-transform": {
-					"version": "0.4.0",
+					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "^1.0.0"
+						"default-require-extensions": "^2.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"arr-flatten": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
 					"bundled": true,
 					"dev": true
 				},
@@ -1022,18 +1015,8 @@
 					"bundled": true,
 					"dev": true
 				},
-				"assign-symbols": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true,
-					"dev": true
-				},
-				"atob": {
-					"version": "2.1.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -1041,61 +1024,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"base": {
-					"version": "0.11.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
@@ -1106,62 +1034,20 @@
 						"concat-map": "0.0.1"
 					}
 				},
-				"braces": {
-					"version": "2.3.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"builtin-modules": {
 					"version": "1.1.1",
 					"bundled": true,
 					"dev": true
 				},
-				"cache-base": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
-					}
-				},
 				"caching-transform": {
-					"version": "1.0.1",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-hex": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"write-file-atomic": "^1.1.4"
+						"make-dir": "^1.0.0",
+						"md5-hex": "^2.0.0",
+						"package-hash": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"camelcase": {
@@ -1178,27 +1064,6 @@
 					"requires": {
 						"align-text": "^0.1.3",
 						"lazy-cache": "^1.0.3"
-					}
-				},
-				"class-utils": {
-					"version": "0.3.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
 					}
 				},
 				"cliui": {
@@ -1225,22 +1090,8 @@
 					"bundled": true,
 					"dev": true
 				},
-				"collection-visit": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
-					}
-				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"component-emitter": {
-					"version": "1.2.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -1251,11 +1102,6 @@
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true,
-					"dev": true
-				},
-				"copy-descriptor": {
-					"version": "0.1.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -1286,68 +1132,26 @@
 					"bundled": true,
 					"dev": true
 				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
-				},
 				"default-require-extensions": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"define-property": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
-					},
-					"dependencies": {
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"error-ex": {
-					"version": "1.3.1",
+					"version": "1.3.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
+				},
+				"es6-error": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
@@ -1375,172 +1179,23 @@
 						}
 					}
 				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
 				"find-cache-dir": {
-					"version": "0.1.1",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
 					}
 				},
 				"find-up": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "^3.0.0"
 					}
-				},
-				"for-in": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
@@ -1551,31 +1206,18 @@
 						"signal-exit": "^3.0.0"
 					}
 				},
-				"fragment-cache": {
-					"version": "0.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"map-cache": "^0.2.2"
-					}
-				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"get-caller-file": {
-					"version": "1.0.2",
+					"version": "1.0.3",
 					"bundled": true,
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"get-value": {
-					"version": "2.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -1618,37 +1260,13 @@
 						}
 					}
 				},
-				"has-value": {
-					"version": "1.0.0",
+				"has-flag": {
+					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
-					}
-				},
-				"has-values": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+					"dev": true
 				},
 				"hosted-git-info": {
-					"version": "2.6.0",
+					"version": "2.7.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -1676,14 +1294,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
 				"is-arrayish": {
 					"version": "0.2.1",
 					"bundled": true,
@@ -1702,89 +1312,13 @@
 						"builtin-modules": "^1.0.0"
 					}
 				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
-				"is-number": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"is-odd": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "^4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"is-plain-object": {
-					"version": "2.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
-				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-utf8": {
-					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
-				},
-				"is-windows": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"isarray": {
-					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -1793,69 +1327,60 @@
 					"bundled": true,
 					"dev": true
 				},
-				"isobject": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true
-				},
 				"istanbul-lib-coverage": {
-					"version": "1.2.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"istanbul-lib-hook": {
-					"version": "1.1.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "^0.4.0"
+						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "1.1.3",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "^1.1.2",
-						"mkdirp": "^0.5.1",
-						"path-parse": "^1.0.5",
-						"supports-color": "^3.1.2"
-					},
-					"dependencies": {
-						"has-flag": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"supports-color": {
-							"version": "3.2.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "^1.0.0"
-							}
-						}
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "1.2.5",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"istanbul-reports": {
-					"version": "1.4.1",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "^4.0.3"
+						"handlebars": "^4.0.11"
 					}
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
@@ -1880,32 +1405,29 @@
 					}
 				},
 				"load-json-file": {
-					"version": "1.1.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
+						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
-					},
-					"dependencies": {
-						"path-exists": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						}
 					}
+				},
+				"lodash.flattendeep": {
+					"version": "4.4.0",
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
@@ -1921,21 +1443,16 @@
 						"yallist": "^2.1.2"
 					}
 				},
-				"map-cache": {
-					"version": "0.2.2",
-					"bundled": true,
-					"dev": true
-				},
-				"map-visit": {
-					"version": "1.0.0",
+				"make-dir": {
+					"version": "1.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-visit": "^1.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"md5-hex": {
-					"version": "1.3.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -1970,33 +1487,6 @@
 						}
 					}
 				},
-				"micromatch": {
-					"version": "3.1.10",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
 				"mimic-fn": {
 					"version": "1.2.0",
 					"bundled": true,
@@ -2011,28 +1501,9 @@
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
+					"version": "0.0.10",
 					"bundled": true,
 					"dev": true
-				},
-				"mixin-deep": {
-					"version": "1.3.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-plain-object": "^2.0.4"
-							}
-						}
-					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -2040,38 +1511,19 @@
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"nanomatch": {
-					"version": "1.2.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-odd": "^2.0.0",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
@@ -2096,47 +1548,6 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"dev": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"object-copy": {
-					"version": "0.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
-				"object-visit": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.0"
-					}
-				},
-				"object.pick": {
-					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isobject": "^3.0.1"
-					}
 				},
 				"once": {
 					"version": "1.4.0",
@@ -2176,46 +1587,50 @@
 					"dev": true
 				},
 				"p-limit": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
+				},
+				"package-hash": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
+					}
 				},
 				"parse-json": {
-					"version": "2.2.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
-				},
-				"pascalcase": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
 				},
 				"path-exists": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
+					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
@@ -2227,62 +1642,26 @@
 					"bundled": true,
 					"dev": true
 				},
-				"path-parse": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
-				},
 				"path-type": {
-					"version": "1.1.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
-					"version": "2.3.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"bundled": true,
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
 				},
 				"pkg-dir": {
-					"version": "1.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						}
+						"find-up": "^3.0.0"
 					}
-				},
-				"posix-character-classes": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
@@ -2290,48 +1669,31 @@
 					"dev": true
 				},
 				"read-pkg": {
-					"version": "1.1.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
+						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
-					"version": "1.0.1",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							}
-						}
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
-				"regex-not": {
-					"version": "1.0.2",
+				"release-zalgo": {
+					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
+						"es6-error": "^4.0.1"
 					}
-				},
-				"repeat-element": {
-					"version": "1.1.2",
-					"bundled": true,
-					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
@@ -2349,17 +1711,7 @@
 					"dev": true
 				},
 				"resolve-from": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"resolve-url": {
-					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
-				},
-				"ret": {
-					"version": "0.1.15",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -2380,14 +1732,6 @@
 						"glob": "^7.0.5"
 					}
 				},
-				"safe-regex": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ret": "~0.1.10"
-					}
-				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
@@ -2397,27 +1741,6 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"set-value": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
@@ -2437,132 +1760,11 @@
 					"bundled": true,
 					"dev": true
 				},
-				"slide": {
-					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
-				},
-				"snapdragon": {
-					"version": "0.8.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"snapdragon-node": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"kind-of": "^6.0.0"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"snapdragon-util": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.2.0"
-					}
-				},
 				"source-map": {
 					"version": "0.5.7",
 					"bundled": true,
-					"dev": true
-				},
-				"source-map-resolve": {
-					"version": "0.5.2",
-					"bundled": true,
 					"dev": true,
-					"requires": {
-						"atob": "^2.1.1",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
-					}
-				},
-				"source-map-url": {
-					"version": "0.4.0",
-					"bundled": true,
-					"dev": true
+					"optional": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
@@ -2605,33 +1807,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"split-string": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^3.0.0"
-					}
-				},
-				"static-extend": {
-					"version": "0.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						}
-					}
-				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
@@ -2650,56 +1825,32 @@
 					}
 				},
 				"strip-bom": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
+					"dev": true
 				},
 				"strip-eof": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
 				"test-exclude": {
-					"version": "4.2.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
-						"micromatch": "^3.1.8",
-						"object-assign": "^4.1.0",
-						"read-pkg-up": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
 						"require-main-filename": "^1.0.1"
-					}
-				},
-				"to-object-path": {
-					"version": "0.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"to-regex": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
 					}
 				},
 				"uglify-js": {
@@ -2733,93 +1884,10 @@
 					"dev": true,
 					"optional": true
 				},
-				"union-value": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^0.4.3"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"set-value": {
-							"version": "0.4.3",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"extend-shallow": "^2.0.1",
-								"is-extendable": "^0.1.1",
-								"is-plain-object": "^2.0.1",
-								"to-object-path": "^0.3.0"
-							}
-						}
-					}
-				},
-				"unset-value": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
-					},
-					"dependencies": {
-						"has-value": {
-							"version": "0.3.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
-							},
-							"dependencies": {
-								"isobject": {
-									"version": "2.1.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"isarray": "1.0.0"
-									}
-								}
-							}
-						},
-						"has-values": {
-							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"urix": {
-					"version": "0.1.0",
+				"uuid": {
+					"version": "3.3.2",
 					"bundled": true,
 					"dev": true
-				},
-				"use": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
@@ -2902,13 +1970,13 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "1.3.4",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"y18n": {
@@ -2940,11 +2008,6 @@
 						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
-						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
@@ -2955,18 +2018,48 @@
 								"wrap-ansi": "^2.0.0"
 							}
 						},
-						"yargs-parser": {
-							"version": "9.0.2",
+						"find-up": {
+							"version": "2.1.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "^4.1.0"
+								"locate-path": "^2.0.0"
 							}
+						},
+						"locate-path": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "1.3.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^1.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^1.1.0"
+							}
+						},
+						"p-try": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "8.1.0",
+					"version": "9.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3012,6 +2105,15 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			}
 		},
 		"pathval": {
 			"version": "1.1.0",
@@ -3075,12 +2177,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
-		"samsam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-			"dev": true
-		},
 		"semver": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
@@ -3099,20 +2195,31 @@
 			}
 		},
 		"sinon": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
-			"integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
+			"version": "6.3.4",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
+			"integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.0.1",
-				"@sinonjs/formatio": "^2.0.0",
-				"@sinonjs/samsam": "^2.0.0",
+				"@sinonjs/commons": "^1.0.2",
+				"@sinonjs/formatio": "^3.0.0",
+				"@sinonjs/samsam": "^2.1.1",
 				"diff": "^3.5.0",
 				"lodash.get": "^4.4.2",
-				"lolex": "^2.7.1",
-				"nise": "^1.4.2",
-				"supports-color": "^5.4.0",
+				"lolex": "^2.7.4",
+				"nise": "^1.4.5",
+				"supports-color": "^5.5.0",
 				"type-detect": "^4.0.8"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"sinon-chai": {
@@ -3176,7 +2283,7 @@
 		},
 		"text-encoding": {
 			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
 			"dev": true
 		},
@@ -3280,6 +2387,14 @@
 				"shelljs": "^0.8.2",
 				"typedoc-default-themes": "^0.5.0",
 				"typescript": "3.0.x"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+					"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+					"dev": true
+				}
 			}
 		},
 		"typedoc-default-themes": {
@@ -3289,9 +2404,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-			"integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+			"integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,23 +124,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@financialforcedev/orizuru": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@financialforcedev/orizuru/-/orizuru-7.0.0.tgz",
-			"integrity": "sha512-XbcIFKFYRlaspliQRUw9Yn9diABurb/JYcKF8CBvYBHCAI7ynj/m+2lsjGfR7l1MM+xXiG15MeyiToh22tkhWg==",
-			"dev": true,
-			"requires": {
-				"@types/express": "^4.16.0",
-				"@types/fs-extra": "^5.0.4",
-				"@types/lodash": "^4.14.116",
-				"@types/node": "^10.7.1",
-				"avsc": "^5.4.2",
-				"express": "^4.16.3",
-				"fs-extra": "^7.0.0",
-				"http-status-codes": "^1.3.0",
-				"lodash": "^4.17.10"
-			}
-		},
 		"@sinonjs/commons": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
@@ -180,16 +163,6 @@
 			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.23.tgz",
 			"integrity": "sha512-xlehmc6RT+wMEhy9ZqeqmozVmuFzTfsaV2NlfFFWhigy7n6sjMbUUB+SZBWK78lZgWHA4DBAdQvQxUvcB8N1tw=="
 		},
-		"@types/body-parser": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-			"integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
-			"dev": true,
-			"requires": {
-				"@types/connect": "*",
-				"@types/node": "*"
-			}
-		},
 		"@types/chai": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
@@ -205,41 +178,10 @@
 				"@types/chai": "*"
 			}
 		},
-		"@types/connect": {
-			"version": "3.4.32",
-			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-			"integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
-		},
-		"@types/express": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
-			"integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
-			"dev": true,
-			"requires": {
-				"@types/body-parser": "*",
-				"@types/express-serve-static-core": "*",
-				"@types/serve-static": "*"
-			}
-		},
-		"@types/express-serve-static-core": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
-			"integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
-			"dev": true,
-			"requires": {
-				"@types/events": "*",
-				"@types/node": "*",
-				"@types/range-parser": "*"
-			}
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
@@ -284,12 +226,6 @@
 			"integrity": "sha512-xkURX55US18wHme+O2UlqJf3Fo7FqT5VAL+OJ/zK+jP2NX57naryDHoiqt/pMIwZjDc62sRvXUWuQQxQiBdheQ==",
 			"dev": true
 		},
-		"@types/mime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-			"integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
-			"dev": true
-		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -306,22 +242,6 @@
 			"version": "10.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
 			"integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
-		},
-		"@types/range-parser": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-			"integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==",
-			"dev": true
-		},
-		"@types/serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
-			"dev": true,
-			"requires": {
-				"@types/express-serve-static-core": "*",
-				"@types/mime": "*"
-			}
 		},
 		"@types/shelljs": {
 			"version": "0.8.0",
@@ -347,16 +267,6 @@
 			"requires": {
 				"@types/chai": "*",
 				"@types/sinon": "*"
-			}
-		},
-		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
 			}
 		},
 		"align-text": {
@@ -412,12 +322,6 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-			"dev": true
-		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -434,12 +338,6 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
-		},
-		"avsc": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/avsc/-/avsc-5.4.2.tgz",
-			"integrity": "sha512-nXfk2U3E/CtPRm05I81q8VUzMvSD7JYejjbE1KiMdqdsmcFx+fs1fv0IUj5yFIloBc+fJy5KGE3hfcZEiOKZLQ==",
 			"dev": true
 		},
 		"babel-code-frame": {
@@ -499,24 +397,6 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
 			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
 		},
-		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-			"dev": true,
-			"requires": {
-				"bytes": "3.0.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
-				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -548,12 +428,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
-		},
-		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
 			"dev": true
 		},
 		"camelcase": {
@@ -662,43 +536,10 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-			"dev": true
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"requires": {
-				"ms": "2.0.0"
-			}
 		},
 		"decamelize": {
 			"version": "1.2.0",
@@ -716,40 +557,10 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -768,85 +579,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
-		},
-		"express": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.5",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.18.2",
-				"content-disposition": "0.5.2",
-				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.3",
-				"qs": "6.5.1",
-				"range-parser": "~1.2.0",
-				"safe-buffer": "5.1.1",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
-				}
-			}
-		},
-		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
-				"unpipe": "~1.0.0"
-			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
 			"dev": true
 		},
 		"fs-extra": {
@@ -954,30 +686,6 @@
 			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
 			"dev": true
 		},
-		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
-			}
-		},
-		"http-status-codes": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
-			"integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y=",
-			"dev": true
-		},
-		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1007,12 +715,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"ipaddr.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -1143,45 +845,6 @@
 			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
 			"dev": true
 		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
-		},
-		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-			"dev": true
-		},
-		"mime-db": {
-			"version": "1.35.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-			"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.19",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-			"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
-			"dev": true,
-			"requires": {
-				"mime-db": "~1.35.0"
-			}
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1240,12 +903,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
 			"dev": true
 		},
 		"nise": {
@@ -3325,15 +2982,6 @@
 				}
 			}
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3353,12 +3001,6 @@
 				"wordwrap": "~0.0.2"
 			}
 		},
-		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-			"dev": true
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3369,12 +3011,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"pathval": {
@@ -3388,66 +3024,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
 			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
 			"dev": true
-		},
-		"proxy-addr": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-			"dev": true,
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.8.0"
-			}
-		},
-		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-			"dev": true
-		},
-		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-			"dev": true
-		},
-		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-			"dev": true,
-			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-					"dev": true
-				},
-				"http-errors": {
-					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"dev": true,
-					"requires": {
-						"depd": "1.1.1",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.3",
-						"statuses": ">= 1.3.1 < 2"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-					"dev": true
-				}
-			}
 		},
 		"readable-stream": {
 			"version": "1.1.14",
@@ -3509,45 +3085,6 @@
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
 			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-			"dev": true
-		},
-		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
-			}
-		},
-		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"dev": true,
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
-			}
-		},
-		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
 			"dev": true
 		},
 		"shelljs": {
@@ -3612,12 +3149,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
 			"dev": true
 		},
 		"string_decoder": {
@@ -3726,16 +3257,6 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
-		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"dev": true,
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
-			}
-		},
 		"typedoc": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
@@ -3796,24 +3317,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
 			"dev": true
 		},
 		"window-size": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"init-project": "cp run.properties local.run.properties && cp test.properties local.test.properties",
 		"prepare": "npm run build",
 		"pretest": "tslint -p tsconfig.json",
-		"test": "nyc mocha"
+		"test": "nyc --nycrc-path=test/nyc.opts mocha"
 	},
 	"repository": {
 		"type": "git",
@@ -51,34 +51,5 @@
 		"tslint": "^5.11.0",
 		"typedoc": "^0.12.0",
 		"typescript": "^3.0.1"
-	},
-	"nyc": {
-		"all": true,
-		"check-coverage": true,
-		"per-file": true,
-		"lines": 100,
-		"statements": 100,
-		"functions": 100,
-		"branches": 100,
-		"require": [
-			"ts-node/register"
-		],
-		"extension": [
-			".ts"
-		],
-		"exclude": [
-			"coverage",
-			"dist",
-			"doc",
-			"**/*.d.ts"
-		],
-		"reporter": [
-			"lcov",
-			"html",
-			"text",
-			"text-summary"
-		],
-		"sourceMap": true,
-		"instrument": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -30,25 +30,25 @@
 	"dependencies": {
 		"@types/amqplib": "0.5.8",
 		"@types/lodash": "^4.14.116",
-		"@types/node": "^10.7.1",
+		"@types/node": "^10.11.3",
 		"amqplib": "^0.5.2",
-		"lodash": "^4.17.10"
+		"lodash": "^4.17.11"
 	},
 	"devDependencies": {
-		"@types/chai": "^4.1.4",
+		"@types/chai": "^4.1.6",
 		"@types/chai-as-promised": "^7.1.0",
 		"@types/mocha": "^5.2.5",
-		"@types/sinon": "^5.0.1",
+		"@types/sinon": "^5.0.2",
 		"@types/sinon-chai": "^3.2.0",
-		"chai": "^4.1.2",
+		"chai": "^4.2.0",
 		"chai-as-promised": "^7.1.1",
 		"mocha": "^5.2.0",
-		"nyc": "^12.0.2",
-		"sinon": "^6.1.5",
+		"nyc": "^13.0.1",
+		"sinon": "^6.3.4",
 		"sinon-chai": "^3.2.0",
 		"ts-node": "^7.0.1",
 		"tslint": "^5.11.0",
 		"typedoc": "^0.12.0",
-		"typescript": "^3.0.1"
+		"typescript": "^3.1.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"lodash": "^4.17.10"
 	},
 	"devDependencies": {
-		"@financialforcedev/orizuru": "^7.0.0",
 		"@types/chai": "^4.1.4",
 		"@types/chai-as-promised": "^7.1.0",
 		"@types/mocha": "^5.2.5",

--- a/readme.md
+++ b/readme.md
@@ -14,33 +14,30 @@ $ npm install @financialforcedev/orizuru-transport-rabbitmq
 
 ## Usage
 
-Use this dependency to specify the transport layer that ```@financialforcedev/orizuru``` uses as RabbitMQ.
+Use this dependency to specify the transport layer that `@financialforcedev/orizuru` uses as RabbitMQ.
 
 ```typescript
 // get classes from orizuru
 import { Handler, Publisher, Server } from '@financialforcedev/orizuru';
 
 // get the transport
-import * as transport from '@financialforcedev/orizuru-transport-rabbitmq';
+import { Transport } from '@financialforcedev/orizuru-transport-rabbitmq';
 
-// configure the transport
-const transportConfig = {
-    cloudamqpUrl:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
-};
+// create the transport
+const transport = new Transport({
+    url:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
+});
 
 const server = new Server({
-    transport,
-    transportConfig
+    transport
 });
 
 const handler = new Handler({
-    transport,
-    transportConfig
+    transport
 });
 
 const publisher = new Publisher({
-    transport,
-    transportConfig
+    transport
 });
 ```
 
@@ -48,9 +45,13 @@ Messages can be published to a [work queue](https://www.rabbitmq.com/tutorials/t
 
 ```typescript
 import { Publisher } from '@financialforcedev/orizuru';
-import * as transport from '@financialforcedev/orizuru-transport-rabbitmq';
+import { Transport } from '@financialforcedev/orizuru-transport-rabbitmq';
 
-const app = new Publisher({ transport, transportConfig });
+const transport = new Transport({
+    url:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
+});
+
+const app = new Publisher({ transport });
 
 app.publish({
     message: {
@@ -69,12 +70,16 @@ and consumed by the handler.
 
 ```typescript
 import { Handler, IOrizuruMessage } from '@financialforcedev/orizuru';
-import * as transport from '@financialforcedev/orizuru-transport-rabbitmq';
+import { Transport } from '@financialforcedev/orizuru-transport-rabbitmq';
 
-const app = new Handler({ transport, transportConfig });
+const transport = new Transport({
+    url:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
+});
+
+const app = new Handler({ transport });
 
 app.handle({
-    handler: ({ context, message }: IOrizuruMessage) => {
+    handler: ({ context, message }: IOrizuruMessage<any, any>) => {
         app.info(context);
         app.info(message);
     }),
@@ -97,9 +102,13 @@ Or via a topic exchange using the [publish/subscribe](https://www.rabbitmq.com/t
 
 ```typescript
 import { Handler, IOrizuruMessage, Publisher } from '@financialforcedev/orizuru';
-import * as transport from '@financialforcedev/orizuru-transport-rabbitmq';
+import { Transport } from '@financialforcedev/orizuru-transport-rabbitmq';
 
-const publisher = new Publisher({ transport, transportConfig });
+const publisherTransport = new Transport({
+    url:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
+});
+
+const publisher = new Publisher({ transport: publisherTransport });
 
 publisher.publish({
     message: {
@@ -116,10 +125,14 @@ publisher.publish({
     }
 });
 
-const app = new Handler({ transport, transportConfig });
+const handlerTransport = new Transport({
+    url:  process.env.CLOUDAMQP_URL || 'amqp://localhost'
+});
+
+const app = new Handler({ transport: handlerTransport});
 
 app.handle({
-    handler: ({ context, message }: IOrizuruMessage) => {
+    handler: ({ context, message }: IOrizuruMessage<any, any>) => {
         app.info(context);
         app.info(message);
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,16 +69,19 @@ declare global {
 
 }
 
-let connection: Connection;
-let publishChannel: Channel;
-let subscribeChannel: Channel;
+let connection: Connection | undefined;
+let publishChannel: Channel | undefined;
+let subscribeChannel: Channel | undefined;
 
 /**
  * Closes the connection.
  */
 export async function close() {
 	if (connection) {
-		connection.close();
+		await connection.close();
+		publishChannel = undefined;
+		subscribeChannel = undefined;
+		connection = undefined;
 	}
 }
 
@@ -118,6 +121,9 @@ export async function connect(options: Options.Transport.IConnect) {
  * @param options
  */
 export async function publish(buffer: Buffer, options: Options.Transport.IPublish) {
+	if (!publishChannel) {
+		throw new Error('Transport has not been initialised.');
+	}
 	const publisher = new Publisher(publishChannel);
 	await publisher.init(options);
 	return publisher.publish(buffer);
@@ -129,6 +135,9 @@ export async function publish(buffer: Buffer, options: Options.Transport.IPublis
  * @param options
  */
 export async function subscribe(handler: (content: Buffer) => Promise<void | Orizuru.IHandlerResponse>, options: Options.Transport.ISubscribe) {
+	if (!subscribeChannel) {
+		throw new Error('Transport has not been initialised.');
+	}
 	const subscriber = new Subscriber(subscribeChannel);
 	await subscriber.init(options);
 	return subscriber.subscribe(handler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import { validate } from './index/optionsValidator';
 import { Publisher } from './index/publish';
 import { Subscriber } from './index/subscribe';
 
+export type ExchangeType = 'fanout' | 'topic';
+
 declare global {
 
 	namespace Orizuru {
@@ -45,8 +47,8 @@ declare global {
 				exchange?: {
 					key?: string;
 					keyFunction?: ((options: Orizuru.Transport.IPublish) => string);
-					name?: string;
-					type?: string;
+					name: string;
+					type: ExchangeType;
 				};
 			}
 
@@ -56,7 +58,7 @@ declare global {
 					key?: string;
 					keyFunction?: ((options: Orizuru.Transport.ISubscribe) => string);
 					name: string;
-					type?: string;
+					type: ExchangeType;
 				};
 			}
 		}
@@ -121,8 +123,6 @@ export class Transport {
 
 	/**
 	 * Publishes a message via AMQP.
-	 * @param buffer
-	 * @param options
 	 */
 	public async publish(buffer: Buffer, options: Orizuru.Transport.IPublish) {
 		if (!this.publishChannel) {
@@ -135,8 +135,6 @@ export class Transport {
 
 	/**
 	 * Handles a message from AMQP.
-	 * @param handler
-	 * @param options
 	 */
 	public async subscribe(handler: (content: Buffer) => Promise<void | Orizuru.IHandlerResponse>, options: Orizuru.Transport.ISubscribe) {
 		if (!this.subscribeChannel) {

--- a/src/index/optionsValidator.ts
+++ b/src/index/optionsValidator.ts
@@ -26,12 +26,12 @@
 
 import _ from 'lodash';
 
-import { Options } from '@financialforcedev/orizuru';
+import { Options } from '..';
 
 /**
  * @private
  */
-export function validate(options: Options.Transport.IConnect) {
+export function validate(options: Options) {
 
 	if (options == null) {
 		throw new Error('Invalid parameter: null options.');

--- a/src/index/publish.ts
+++ b/src/index/publish.ts
@@ -42,9 +42,8 @@ export class Publisher {
 
 		if (options.exchange) {
 
-			const exchange = options.exchange;
-			const name = exchange.name as string;
-			const type = exchange.type || 'fanout';
+			const { exchange } = options;
+			const { name, type } = exchange;
 			const key = exchange.key || exchange.keyFunction && exchange.keyFunction(options) || '';
 
 			// Ensure the exchange exists
@@ -56,7 +55,7 @@ export class Publisher {
 
 		} else {
 
-			const eventName = options.eventName as string;
+			const { eventName } = options;
 
 			// Ensure the queue exists
 			await this.channel.assertQueue(eventName);

--- a/src/index/publish.ts
+++ b/src/index/publish.ts
@@ -26,8 +26,6 @@
 
 import { Channel } from 'amqplib';
 
-import { Options } from '@financialforcedev/orizuru';
-
 /**
  * @private
  */
@@ -40,7 +38,7 @@ export class Publisher {
 		this.channel = channel;
 	}
 
-	public async init(options: Options.Transport.IPublish) {
+	public async init(options: Orizuru.Transport.IPublish) {
 
 		if (options.exchange) {
 

--- a/src/index/subscribe.ts
+++ b/src/index/subscribe.ts
@@ -26,8 +26,6 @@
 
 import { Channel, Message } from 'amqplib';
 
-import { Options } from '@financialforcedev/orizuru';
-
 /**
  * @private
  */
@@ -40,7 +38,7 @@ export class Subscriber {
 		this.channel = channel;
 	}
 
-	public async init(options: Options.Transport.ISubscribe) {
+	public async init(options: Orizuru.Transport.ISubscribe) {
 
 		this.eventName = options.eventName;
 

--- a/src/index/subscribe.ts
+++ b/src/index/subscribe.ts
@@ -44,9 +44,8 @@ export class Subscriber {
 
 		if (options.exchange) {
 
-			const exchange = options.exchange;
-			const name = exchange.name;
-			const type = exchange.type || 'fanout';
+			const { exchange } = options;
+			const { name, type } = exchange;
 			const key = exchange.key || '';
 
 			await this.channel.assertExchange(name, type, { durable: false });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,6 +90,10 @@ describe('index', () => {
 			await transport.close();
 
 			// Then
+			expect(transport.connection).to.be.undefined;
+			expect(transport.publishChannel).to.be.undefined;
+			expect(transport.subscribeChannel).to.be.undefined;
+
 			expect(amqp.connect).to.have.been.calledOnce;
 			expect(amqp.connect).to.have.been.calledWith('testUrl');
 			expect(connection.createChannel).to.have.been.calledTwice;
@@ -105,6 +109,10 @@ describe('index', () => {
 			await transport.close();
 
 			// Then
+			expect(transport.connection).to.be.undefined;
+			expect(transport.publishChannel).to.be.undefined;
+			expect(transport.subscribeChannel).to.be.undefined;
+
 			expect(amqp.connect).to.not.have.been.called;
 			expect(connection.createChannel).to.not.have.been.called;
 			expect(channel.prefetch).to.not.have.been.called;
@@ -164,6 +172,16 @@ describe('index', () => {
 
 	describe('publish', () => {
 
+		it('should throw an error if the transport has been initialised', () => {
+
+			// Given
+			const buffer = new Buffer('test');
+
+			// When
+			expect(transport.publish(buffer, {})).to.be.rejectedWith('Transport has not been initialised.');
+
+		});
+
 		it('should publish the message buffer', async () => {
 
 			// Given
@@ -187,6 +205,17 @@ describe('index', () => {
 	});
 
 	describe('subscribe', () => {
+
+		it('should throw an error if the transport has been initialised', () => {
+
+			// Given
+			const handler = sinon.stub();
+			const options = { eventName: 'test' };
+
+			// When
+			expect(transport.subscribe(handler, options)).to.be.rejectedWith('Transport has not been initialised.');
+
+		});
 
 		it('should subscribe with the handler', async () => {
 

--- a/test/index/publish.test.ts
+++ b/test/index/publish.test.ts
@@ -99,10 +99,11 @@ describe('index/publish', () => {
 			// Given
 			const buffer = new Buffer('test');
 
-			const options = {
+			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',
 				exchange: {
-					name: 'exchange1'
+					name: 'exchange1',
+					type: 'fanout'
 				}
 			};
 
@@ -126,7 +127,7 @@ describe('index/publish', () => {
 			// Given
 			const buffer = new Buffer('test');
 
-			const options = {
+			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',
 				exchange: {
 					key: 'testKey',
@@ -155,7 +156,7 @@ describe('index/publish', () => {
 			// Given
 			const buffer = new Buffer('test');
 
-			const options = {
+			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',
 				exchange: {
 					keyFunction: () => {

--- a/test/index/publish.test.ts
+++ b/test/index/publish.test.ts
@@ -89,7 +89,7 @@ describe('index/publish', () => {
 
 			// Then
 			expect(channel.sendToQueue).to.have.been.calledOnce;
-			expect(channel.sendToQueue).to.have.been.calledWith('test', buffer);
+			expect(channel.sendToQueue).to.have.been.calledWithExactly('test', buffer);
 			expect(channel.assertExchange).to.not.have.been.called;
 
 		});
@@ -114,9 +114,9 @@ describe('index/publish', () => {
 
 			// Then
 			expect(channel.assertExchange).to.have.been.calledOnce;
-			expect(channel.assertExchange).to.have.been.calledWith('exchange1', 'fanout', { durable: false });
+			expect(channel.assertExchange).to.have.been.calledWithExactly('exchange1', 'fanout', { durable: false });
 			expect(channel.publish).to.have.been.calledOnce;
-			expect(channel.publish).to.have.been.calledWith('exchange1', '', buffer);
+			expect(channel.publish).to.have.been.calledWithExactly('exchange1', '', buffer);
 			expect(channel.sendToQueue).to.not.have.been.called;
 
 		});
@@ -143,9 +143,9 @@ describe('index/publish', () => {
 
 			// Then
 			expect(channel.assertExchange).to.have.been.calledOnce;
-			expect(channel.assertExchange).to.have.been.calledWith('exchange1', 'topic', { durable: false });
+			expect(channel.assertExchange).to.have.been.calledWithExactly('exchange1', 'topic', { durable: false });
 			expect(channel.publish).to.have.been.calledOnce;
-			expect(channel.publish).to.have.been.calledWith('exchange1', 'testKey', buffer);
+			expect(channel.publish).to.have.been.calledWithExactly('exchange1', 'testKey', buffer);
 			expect(channel.sendToQueue).to.not.have.been.called;
 
 		});
@@ -174,9 +174,9 @@ describe('index/publish', () => {
 
 			// Then
 			expect(channel.assertExchange).to.have.been.calledOnce;
-			expect(channel.assertExchange).to.have.been.calledWith('exchange1', 'topic', { durable: false });
+			expect(channel.assertExchange).to.have.been.calledWithExactly('exchange1', 'topic', { durable: false });
 			expect(channel.publish).to.have.been.calledOnce;
-			expect(channel.publish).to.have.been.calledWith('exchange1', 'testKey', buffer);
+			expect(channel.publish).to.have.been.calledWithExactly('exchange1', 'testKey', buffer);
 			expect(channel.sendToQueue).to.not.have.been.called;
 
 		});

--- a/test/index/subscribe.test.ts
+++ b/test/index/subscribe.test.ts
@@ -111,10 +111,11 @@ describe('index/subscribe', () => {
 
 			const handler = sinon.stub();
 
-			const options = {
+			const options: Orizuru.Transport.ISubscribe = {
 				eventName: 'eventName',
 				exchange: {
-					name: 'testExchange'
+					name: 'testExchange',
+					type: 'fanout'
 				}
 			};
 
@@ -142,7 +143,7 @@ describe('index/subscribe', () => {
 
 			const handler = sinon.stub();
 
-			const options = {
+			const options: Orizuru.Transport.ISubscribe = {
 				eventName: 'eventName'
 			};
 

--- a/test/nyc.opts
+++ b/test/nyc.opts
@@ -1,0 +1,29 @@
+{
+	"all": true,
+	"check-coverage": true,
+	"per-file": true,
+	"lines": 100,
+	"statements": 100,
+	"functions": 100,
+	"branches": 100,
+	"require": [
+		"ts-node/register"
+	],
+	"extension": [
+		".ts"
+	],
+	"exclude": [
+		"coverage",
+		"dist",
+		"doc",
+		"**/*.d.ts"
+	],
+	"reporter": [
+		"lcov",
+		"html",
+		"text",
+		"text-summary"
+	],
+	"sourceMap": true,
+	"instrument": true
+}

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,14 @@
 			"tabs",
 			4
 		],
+		"interface-name": false,
+		"max-line-length": false,
+		"no-any": false,
+		"no-namespace": [
+			false,
+			"allow-declarations"
+		],
+		"no-unused-expression": false,
 		"quotemark": [
 			true,
 			"single"
@@ -20,13 +28,6 @@
 				"multiline": "never",
 				"singleline": "never"
 			}
-		],
-		"max-line-length": false,
-		"no-unused-expression": false,
-		"no-any": false,
-		"no-namespace": [
-			false,
-			"allow-declarations"
 		]
 	},
 	"rulesDirectory": []


### PR DESCRIPTION
As part of writing some system tests for Orizuru, I ran into problems when trying to create multiple servers and handlers due to the way that the transport layer creates one shared connection. This PR addresses this issue.

Moving over to a class also allows us to update Orizuru so that the `transportConfig` is part of the constructor of the transport and remove the requirement for the `IConnect` interface completely.

I intend to release this as a premajor so that we can test out the functionality before releasing V5.

## 5.0.0-0 PREMAJOR

 - Update Orizuru to use a class for the transport layer.
	- Each server, publisher and handler should have a different transport instance.
	- The configuration for the transport can be provided in the constructor thereby removing the requirement of transportConfig from Orizuru.
- Update all references to the Orizuru.Options; use Orizuru.Transport... instead.
- Remove the use of Orizuru.Transport.IConnect.
- Remove the Orizuru dev dependency.
 - Add nyc.opts file to clean up the package.json.