### PR TITLE
Feature/update for node 10 changes

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,1 +1,5 @@
 ## Latest
+
+- Update all dependencies to latest versions
+- Remove all references to `new Buffer()`
+	- Use `Buffer.from()` instead to remove deprecation warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,9 +120,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-			"integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -170,9 +170,9 @@
 			"integrity": "sha512-xlehmc6RT+wMEhy9ZqeqmozVmuFzTfsaV2NlfFFWhigy7n6sjMbUUB+SZBWK78lZgWHA4DBAdQvQxUvcB8N1tw=="
 		},
 		"@types/chai": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
-			"integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+			"integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
 			"dev": true
 		},
 		"@types/chai-as-promised": {
@@ -222,9 +222,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.117",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-			"integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
+			"version": "4.14.118",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
+			"integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw=="
 		},
 		"@types/marked": {
 			"version": "0.4.2",
@@ -245,9 +245,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-			"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+			"version": "10.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
 		},
 		"@types/shelljs": {
 			"version": "0.8.0",
@@ -2089,18 +2089,18 @@
 			}
 		},
 		"sinon": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.0.0.tgz",
-			"integrity": "sha512-8OrSYFPZ9xaECfi1ayVMd0ihYCW2OZYgX3rBczrB990gHZMM+aftvhNTJazGz/luS0Us9NWgD5P3KGQ7kYZvGg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+			"integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.0.2",
+				"@sinonjs/commons": "^1.2.0",
 				"@sinonjs/formatio": "^3.0.0",
 				"@sinonjs/samsam": "^2.1.2",
 				"diff": "^3.5.0",
 				"lodash.get": "^4.4.2",
 				"lolex": "^3.0.0",
-				"nise": "^1.4.5",
+				"nise": "^1.4.6",
 				"supports-color": "^5.5.0",
 				"type-detect": "^4.0.8"
 			},
@@ -2290,9 +2290,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-			"integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
 	"license": "BSD-3-Clause",
 	"dependencies": {
 		"@types/amqplib": "0.5.8",
-		"@types/lodash": "^4.14.117",
-		"@types/node": "^10.12.0",
+		"@types/lodash": "^4.14.118",
+		"@types/node": "^10.12.2",
 		"amqplib": "^0.5.2",
 		"lodash": "^4.17.11"
 	},
 	"devDependencies": {
-		"@types/chai": "^4.1.6",
+		"@types/chai": "^4.1.7",
 		"@types/chai-as-promised": "^7.1.0",
 		"@types/mocha": "^5.2.5",
 		"@types/sinon": "^5.0.5",
@@ -44,11 +44,11 @@
 		"chai-as-promised": "^7.1.1",
 		"mocha": "^5.2.0",
 		"nyc": "^13.1.0",
-		"sinon": "^7.0.0",
+		"sinon": "^7.1.1",
 		"sinon-chai": "^3.2.0",
 		"ts-node": "^7.0.1",
 		"tslint": "^5.11.0",
 		"typedoc": "^0.13.0",
-		"typescript": "^3.1.3"
+		"typescript": "^3.1.6"
 	}
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -214,7 +214,7 @@ describe('index', () => {
 		it('should throw an error if the transport has not been initialised', () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			// When
 			expect(transport.publish(buffer, {})).to.be.rejectedWith('Transport has not been initialised.');
@@ -224,7 +224,7 @@ describe('index', () => {
 		it('should publish the message buffer', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			sinon.stub(Publisher.prototype, 'init');
 			sinon.stub(Publisher.prototype, 'publish');

--- a/test/index/publish.test.ts
+++ b/test/index/publish.test.ts
@@ -58,7 +58,7 @@ describe('index/publish', () => {
 		it('should throw an error if the publisher has not been initialised', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			const publish = new Publisher(channel);
 
@@ -75,7 +75,7 @@ describe('index/publish', () => {
 		it('should publish to a queue', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			const options = {
 				eventName: 'test'
@@ -97,7 +97,7 @@ describe('index/publish', () => {
 		it('should publish to a fanout exchange', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',
@@ -125,7 +125,7 @@ describe('index/publish', () => {
 		it('should publish to a topic exchange', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',
@@ -154,7 +154,7 @@ describe('index/publish', () => {
 		it('should publish to a topic exchange using the keyFunction', async () => {
 
 			// Given
-			const buffer = new Buffer('test');
+			const buffer = Buffer.from('test');
 
 			const options: Orizuru.Transport.IPublish = {
 				eventName: 'test',


### PR DESCRIPTION
- Update all dependencies to latest versions
- Remove all references to `new Buffer()`
	- Use `Buffer.from()` instead to remove deprecation warnings