### PR TITLE
Release/2018 10 07

### DIFF
--- a/CHANGELOG-5.md
+++ b/CHANGELOG-5.md
@@ -1,5 +1,11 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
+## 5.0.1
+
+- Update all dependencies to latest versions
+- Remove all references to `new Buffer()`
+	- Use `Buffer.from()` instead to remove deprecation warnings
+
 ## 5.0.0
 
 - Update Orizuru to use a class for the transport layer.

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,5 +1,1 @@
 ## Latest
-
-- Update all dependencies to latest versions
-- Remove all references to `new Buffer()`
-	- Use `Buffer.from()` instead to remove deprecation warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru-transport-rabbitmq",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru-transport-rabbitmq",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Rabbitmq transport layer for the orizuru package",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 5.0.1
 - Update all dependencies to latest versions
- Remove all references to `new Buffer()`
	- Use `Buffer.from()` instead to remove deprecation warnings