### PR TITLE
Added closeChannel method

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,4 +1,5 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
-## Latest changes (not yet released)
-- Update `Transport.close()` function to close channels. Close function has a new optional parameter `options: {flush: boolean}` set to false by default. If `options.flush` is set to true then channels are closed. 
+### FIXES
+
+- Make `Transport.close()` flush its message channels before closing the connection.

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,4 +1,4 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
 ## Latest changes (not yet released)
-
+- Update `Transport.close()` function to close channels. Close function has a new optional parameter `options: {flush: boolean}` set to false by default. If `options.flush` is set to true then channels are closed. 

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,5 +1,7 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
+## Latest changes (not yet released)
+
 ### FIXES
 
 - Make `Transport.close()` flush its message channels before closing the connection.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,12 +88,12 @@ export class Transport {
 	/**
 	 * Closes the connection.
 	 */
-	public async close(options: { flush?: boolean } = { flush: false }) {
-		if (options.flush && this.publishChannel) {
+	public async close() {
+		if (this.publishChannel) {
 			await this.publishChannel.close();
 		}
 
-		if (options.flush && this.subscribeChannel) {
+		if (this.subscribeChannel) {
 			await this.subscribeChannel.close();
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,6 @@ export class Transport {
 	 */
 	public async closeChannel() {
 		if (this.publishChannel) {
-			console.warn('DEBUG**** Closing channel ');
 			await this.publishChannel.close();
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,10 @@ export class Transport {
 			await this.publishChannel.close();
 		}
 
+		if (flush && this.subscribeChannel) {
+			await this.subscribeChannel.close();
+		}
+
 		if (this.connection) {
 			await this.connection.close();
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,18 +88,13 @@ export class Transport {
 	/**
 	 * Closes the connection.
 	 */
-	public async close() {
+	public async close(flush: boolean = false) {
+		if (flush && this.publishChannel) {
+			await this.publishChannel.close();
+		}
+
 		if (this.connection) {
 			await this.connection.close();
-		}
-	}
-
-	/**
-	 * Closes the channel.
-	 */
-	public async closeChannel() {
-		if (this.publishChannel) {
-			await this.publishChannel.close();
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,12 +88,12 @@ export class Transport {
 	/**
 	 * Closes the connection.
 	 */
-	public async close(flush: boolean = false) {
-		if (flush && this.publishChannel) {
+	public async close(options: { flush?: boolean } = { flush: false }) {
+		if (options.flush && this.publishChannel) {
 			await this.publishChannel.close();
 		}
 
-		if (flush && this.subscribeChannel) {
+		if (options.flush && this.subscribeChannel) {
 			await this.subscribeChannel.close();
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,16 @@ export class Transport {
 	}
 
 	/**
+	 * Closes the channel.
+	 */
+	public async closeChannel() {
+		if (this.publishChannel) {
+			console.warn('DEBUG**** Closing channel ');
+			await this.publishChannel.close();
+		}
+	}
+
+	/**
 	 * Connects to AMQP and creates a publish and subscribe channel.
 	 */
 	public async connect() {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -138,10 +138,6 @@ describe('index', () => {
 
 		});
 
-	});
-
-	describe('closeChannel', () => {
-
 		it('should close the channel if connect with flush set to true', async () => {
 
 			// Given

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,7 +135,7 @@ describe('index', () => {
 			expect(amqp.connect).to.not.have.been.called;
 			expect(connection.createChannel).to.not.have.been.called;
 			expect(channel.prefetch).to.not.have.been.called;
-			expect(channel.close).to.have.not.been.calledOnce;
+			expect(channel.close).to.have.not.been.called;
 			expect(connection.close).to.not.have.been.called;
 
 		});
@@ -155,7 +155,7 @@ describe('index', () => {
 			expect(amqp.connect).to.not.have.been.called;
 			expect(connection.createChannel).to.not.have.been.called;
 			expect(channel.prefetch).to.not.have.been.called;
-			expect(channel.close).to.not.have.been.calledOnce;
+			expect(channel.close).to.not.have.been;
 			expect(connection.close).to.not.have.been.called;
 
 		});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -97,7 +97,7 @@ describe('index', () => {
 
 	describe('close', () => {
 
-		it('should close the connection if connect has been called', async () => {
+		it('should close the connection and channels if connect has been called', async () => {
 
 			// Given
 			transport = new Transport({
@@ -115,11 +115,12 @@ describe('index', () => {
 			expect(amqp.connect).to.have.been.calledWithExactly('amqp://localhost');
 			expect(connection.createChannel).to.have.been.calledTwice;
 			expect(channel.prefetch).to.not.have.been.called;
+			expect(channel.close).to.have.been.calledTwice;
 			expect(connection.close).to.have.been.calledOnce;
 
 		});
 
-		it('should ignore closing the connection if connect has not been called', async () => {
+		it('should ignore closing the connection and channels if connect has not been called', async () => {
 
 			// Given
 			transport = new Transport({
@@ -134,59 +135,8 @@ describe('index', () => {
 			expect(amqp.connect).to.not.have.been.called;
 			expect(connection.createChannel).to.not.have.been.called;
 			expect(channel.prefetch).to.not.have.been.called;
-			expect(connection.close).to.not.have.been.called;
-
-		});
-
-		it('should close the channel if connect with flush set to true', async () => {
-
-			// Given
-			transport = new Transport({
-				url: 'amqp://localhost'
-			});
-
-			sinon.stub(Publisher.prototype, 'init');
-			sinon.stub(Publisher.prototype, 'publish');
-
-			await transport.connect({ url: 'testUrl' });
-
-			// When
-			await transport.close({ flush: true });
-
-			// Then
-			expect(optionsValidator.validate).to.have.been.calledOnce;
-			expect(amqp.connect).to.have.been.calledOnce;
-			expect(amqp.connect).to.have.been.calledWithExactly('amqp://localhost');
-			expect(connection.createChannel).to.have.been.calledTwice;
-			expect(channel.prefetch).to.not.have.been.called;
-			expect(channel.close).to.have.been.calledTwice;
-			expect(connection.close).to.have.been.calledOnce;
-
-		});
-
-		it('should not close the channel if connect without flush set', async () => {
-
-			// Given
-			transport = new Transport({
-				url: 'amqp://localhost'
-			});
-
-			sinon.stub(Publisher.prototype, 'init');
-			sinon.stub(Publisher.prototype, 'publish');
-
-			await transport.connect({ url: 'testUrl' });
-
-			// When
-			await transport.close();
-
-			// Then
-			expect(optionsValidator.validate).to.have.been.calledOnce;
-			expect(amqp.connect).to.have.been.calledOnce;
-			expect(amqp.connect).to.have.been.calledWithExactly('amqp://localhost');
-			expect(connection.createChannel).to.have.been.calledTwice;
-			expect(channel.prefetch).to.not.have.been.called;
 			expect(channel.close).to.have.not.been.calledOnce;
-			expect(connection.close).to.have.been.calledOnce;
+			expect(connection.close).to.not.have.been.called;
 
 		});
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -151,7 +151,7 @@ describe('index', () => {
 			await transport.connect({ url: 'testUrl' });
 
 			// When
-			await transport.close(true);
+			await transport.close({ flush: true });
 
 			// Then
 			expect(optionsValidator.validate).to.have.been.calledOnce;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -163,7 +163,7 @@ describe('index', () => {
 			expect(amqp.connect).to.have.been.calledWithExactly('amqp://localhost');
 			expect(connection.createChannel).to.have.been.calledTwice;
 			expect(channel.prefetch).to.not.have.been.called;
-			expect(channel.close).to.have.been.calledOnce;
+			expect(channel.close).to.have.been.calledTwice;
 			expect(connection.close).to.have.been.calledOnce;
 
 		});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -155,7 +155,7 @@ describe('index', () => {
 			expect(amqp.connect).to.not.have.been.called;
 			expect(connection.createChannel).to.not.have.been.called;
 			expect(channel.prefetch).to.not.have.been.called;
-			expect(channel.close).to.not.have.been;
+			expect(channel.close).to.not.have.been.called;
 			expect(connection.close).to.not.have.been.called;
 
 		});


### PR DESCRIPTION
# FIXES
 * Provide a way to close the `publishChannel`
Messages are not sent if the `connection` is closed without closing the `channel` first. This was leading processes where the connection was not closed.