### PR TITLE
Release/2019 04 02

### DIFF
--- a/CHANGELOG-5.md
+++ b/CHANGELOG-5.md
@@ -1,5 +1,15 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
+## 5.2.0
+
+### NEW FEATURES
+
+- Added forceSecure to the configuration options, this will force the protocol of the connection URL to be amqps.
+
+### FIXES
+
+- Make `Transport.close()` flush its message channels before closing the connection.
+
 ## 5.1.0
 
 ### NEW FEATURES
@@ -29,3 +39,4 @@
 
 ### OTHER CHANGES
 - Add nyc.opts file to clean up the package.json
+

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,11 +1,3 @@
 # @financialforcedev/orizuru-transport-rabbitmq
 
 ## Latest changes (not yet released)
-
-### NEW FEATURES
-
-- Added forceSecure to the configuration options, this will force the protocol of the connection URL to be amqps.
-
-### FIXES
-
-- Make `Transport.close()` flush its message channels before closing the connection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru-transport-rabbitmq",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru-transport-rabbitmq",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"description": "Rabbitmq transport layer for the orizuru package",
 	"main": "dist/src/index.js",
 	"types": "dist/types/src/index.d.ts",


### PR DESCRIPTION
## 5.2.0

### NEW FEATURES

- Added forceSecure to the configuration options, this will force the protocol of the connection URL to be amqps.

### FIXES

- Make `Transport.close()` flush its message channels before closing the connection.
